### PR TITLE
Fix typo on main screen.

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
 
             <p>
                 If you are a front-end developer like we are you might love setting up
-                and maintaining the build workflow like we do. <i>Not at all</i>. Fiddeling
+                and maintaining the build workflow like we do. <i>Not at all</i>. Fiddling
                 around with <i>grunt</i> or the new and fancy <i>gulp.js</i> config files is
                 no fun so a lot of boilerplates were set up to help you. This is another
                 approach to enable you to <b>shorten the build setup</b> with a graphical user interface for <b>automatic gulp.js creation</b> and file upload for <b>dropbox</b>


### PR DESCRIPTION
The active form of "fiddle" doesn't have an "e".
