### PR TITLE
Use http://npmsearch.com as package search endpoint.

### DIFF
--- a/src/npm/search/model/npm-package.js
+++ b/src/npm/search/model/npm-package.js
@@ -8,9 +8,9 @@
             var page = 0;
             var query = 'keywords:gulpplugin,gulpfriendly';
 
-            var NPM_URL = 'http://registry.gulpjs.com/_search';
+            var NPM_URL = 'http://npmsearch.com/query';
             var GITHUB_URL = 'https://api.github.com/repos/:owner/:repoName/readme';
-            var NPM_URL_COUNT = 'http://registry.gulpjs.com/_count';
+            var NPM_URL_COUNT = 'http://npmsearch.com/query';
 
             var NpmPackage = $resource(NPM_URL, {
             }, {
@@ -33,16 +33,19 @@
 
             NpmPackage.getSearchParams = function () {
                 return {
-                    from: page * pageSize,
-                    size: pageSize,
-                    pretty: true,
-                    q: query
+                    size: page * pageSize,
+                    q: ['keywords:gulpplugin', 'keywords:gulpfriendly'],
+                    sort: 'rating:desc',
+                    fields: 'name,keywords,rating,description,author,modified,homepage,version',
                 };
             };
 
             NpmPackage.getMaxPageSizeParams = function () {
                 return {
-                    q: query
+                    size: 1,
+                    q: ['keywords:gulpplugin', 'keywords:gulpfriendly'],
+                    sort: 'rating:desc',
+                    fields: 'name,keywords,rating,description,author,modified,homepage,version',
                 };
             };
 

--- a/src/npm/search/service/npm-package-cache.js
+++ b/src/npm/search/service/npm-package-cache.js
@@ -20,14 +20,14 @@
                 var countParams = NpmPackage.getMaxPageSizeParams();
 
                 return NpmPackage.count(countParams).$promise.then(function (response) {
-
-                    params.size = response.count;
+                    params.size = response.total;
 
                     return NpmPackage.search(params).$promise.then(function (response) {
-                        // This removes strange "undefined" package https://github.com/Gozala/undefined.js
-                        response.hits.hits.splice(0, 1);
-                        self.packages = response.hits.hits.map(function (res) {
-                            return res._source;
+                        self.packages = response.results.map(function (r) {
+                            return {
+                                name: r.name[0],
+                                description: r.description[0]
+                            };
                         });
                         return self.packages;
                     });


### PR DESCRIPTION
The previous endpoint stopped to work.
This fixes #11 and fixes #12
